### PR TITLE
Modified Delegated Notifications Functionalities  and Added Relevant Test Cases

### DIFF
--- a/packages/hardhat/.env
+++ b/packages/hardhat/.env
@@ -1,0 +1,5 @@
+# FILE SYSTEM PATHS
+FS_ARTIFCATS=artifacts
+FS_DEPLOYMENT_INFO=deployment_info
+FS_BULK_EXPORT=bulk_export
+FS_VERSIONING_INFO=version_control

--- a/packages/hardhat/test/EPNSCoreV1/EPNSCoreV1.Notifications.js
+++ b/packages/hardhat/test/EPNSCoreV1/EPNSCoreV1.Notifications.js
@@ -132,8 +132,8 @@ describe("EPNSCoreV1 tests", function () {
         await MOCKDAI.connect(CHANNEL_CREATORSIGNER).approve(EPNSCoreV1Proxy.address, ADD_CHANNEL_MIN_POOL_CONTRIBUTION);
         await EPNSCoreV1Proxy.connect(CHANNEL_CREATORSIGNER).createChannelWithFees(CHANNEL_TYPE, testChannel, {gasLimit: 2000000});
 
-        await MOCKDAI.connect(CHANNEL_CREATORSIGNER).mint(DELEGATED_CONTRACT_FEES);
-        await MOCKDAI.connect(CHANNEL_CREATORSIGNER).approve(EPNSCoreV1Proxy.address, DELEGATED_CONTRACT_FEES);
+        // await MOCKDAI.connect(CHANNEL_CREATORSIGNER).mint(DELEGATED_CONTRACT_FEES);
+        // await MOCKDAI.connect(CHANNEL_CREATORSIGNER).approve(EPNSCoreV1Proxy.address, DELEGATED_CONTRACT_FEES);
       });
 
       it("should revert if anyone other than owner calls the function", async function(){
@@ -145,14 +145,23 @@ describe("EPNSCoreV1 tests", function () {
       it("should emit SendNotification when owner calls", async function(){
         const msg = ethers.utils.toUtf8Bytes("This is notification message");
         const tx = EPNSCoreV1Proxy.connect(CHANNEL_CREATORSIGNER).sendNotification(BOB, msg);
-        
+
         await expect(tx)
           .to.emit(EPNSCoreV1Proxy, 'SendNotification')
           .withArgs(CHANNEL_CREATOR, BOB, ethers.utils.hexlify(msg));
       });
     });
 
-    describe("Testing sendNotificationOverrideChannel", function(){
+    /**
+     * Test Objectives 
+     * No address should be able to access sendNotificationAsDelegate unless added as a Delegate by Channel Owner
+     * Channel Owner should be able to Add/Revoke Delegate to send notifications on behalf of a particular channel.
+     * Only Owner should be able to call the Add/Revoke functionalities
+     * Address added as Delegate should be able to send notification for the channel.
+     * Address whose Delegate notification sending permission is revoked, shouldn't be able to send any notifications 
+    */
+
+    describe("Testing sendNotificationAsDelegate function", function(){
       beforeEach(async function(){
         const CHANNEL_TYPE = 2;
         const testChannel = ethers.utils.toUtf8Bytes("test-channel-hello-world");
@@ -164,29 +173,49 @@ describe("EPNSCoreV1 tests", function () {
         await EPNSCoreV1Proxy.connect(CHANNEL_CREATORSIGNER).createChannelWithFees(CHANNEL_TYPE, testChannel, {gasLimit: 2000000});
       });
 
-      it("should revert if anyone other than owner or gov calls the function", async function(){
-        const msg = ethers.utils.toUtf8Bytes("This is notification message");
-        const tx = EPNSCoreV1Proxy.connect(CHARLIESIGNER).sendNotificationOverrideChannel(CHANNEL_CREATOR, BOB, msg);
-        await expect(tx).to.be.revertedWith("Channel doesn't Exists");
+      it("No one except a Delegate should be able to send notification on behalf of a Channel", async function(){
+        const msg = ethers.utils.toUtf8Bytes("This is DELAGATED notification message");
+        const tx =  EPNSCoreV1Proxy.connect(BOBSIGNER).sendNotificationAsDelegate(CHANNEL_CREATOR,BOB,msg);
+        await expect(tx).to.be.revertedWith("Not authorised to send messages");
       });
 
-      it("should emit SendNotification when gov calls the function", async function(){
-        const msg = ethers.utils.toUtf8Bytes("This is notification message");
-        const tx = EPNSCoreV1Proxy.sendNotificationOverrideChannel(CHANNEL_CREATOR, BOB, msg);
-
-        await expect(tx)
-          .to.emit(EPNSCoreV1Proxy, 'SendNotification')
-          .withArgs(CHANNEL_CREATOR, BOB, ethers.utils.hexlify(msg));
-      });
-
-      it("should emit SendNotification when owner calls the function", async function(){
-        const msg = ethers.utils.toUtf8Bytes("This is notification message");
-        const tx = EPNSCoreV1Proxy.connect(CHANNEL_CREATORSIGNER).sendNotificationOverrideChannel(CHANNEL_CREATOR, BOB, msg);
+      it("BOB Should be able to Send Delegated Notification once Allowed", async function(){
+        // Adding BOB As Delate Notification Seder
+        const tx_addDelegate =  await EPNSCoreV1Proxy.connect(CHANNEL_CREATORSIGNER).addDelegate(BOB);
+        const isBobAllowed = await EPNSCoreV1Proxy.connect(CHANNEL_CREATORSIGNER).delegated_NotificationSenders(CHANNEL_CREATOR,BOB);
         
-        await expect(tx)
+        // BOB Sending Delegated Notification
+        const msg = ethers.utils.toUtf8Bytes("This is DELAGATED notification message");
+        const tx_sendNotif =  await EPNSCoreV1Proxy.connect(BOBSIGNER).sendNotificationAsDelegate(CHANNEL_CREATOR,ALICE,msg);
+        
+        await expect(tx_sendNotif)
           .to.emit(EPNSCoreV1Proxy, 'SendNotification')
-          .withArgs(CHANNEL_CREATOR, BOB, ethers.utils.hexlify(msg));
-      });
+          .withArgs(CHANNEL_CREATOR, ALICE, ethers.utils.hexlify(msg));
+        await expect(isBobAllowed).to.be.equal(true);
+        await expect(tx_addDelegate)
+          .to.emit(EPNSCoreV1Proxy, 'AddDelegate')
+          .withArgs(CHANNEL_CREATOR, BOB);
+      })
+      
+       it("BOB Should NOT be able to Send Delegated Notification once Permission is Revoked", async function(){
+        // Revoking Permission from BOB
+        const tx_removeDelegate =  EPNSCoreV1Proxy.connect(CHANNEL_CREATORSIGNER).removeDelegate(BOB);
+        const isBobAllowed = await EPNSCoreV1Proxy.connect(CHANNEL_CREATORSIGNER).delegated_NotificationSenders(CHANNEL_CREATOR,BOB);
+
+        // BOB Sending Delegated Notification
+         const msg = ethers.utils.toUtf8Bytes("This is DELAGATED notification message");
+        const tx_sendNotif =  EPNSCoreV1Proxy.connect(BOBSIGNER).sendNotificationAsDelegate(CHANNEL_CREATOR,BOB,msg);
+        
+
+        await expect(tx_sendNotif).to.be.revertedWith("Not authorised to send messages");
+        await expect(isBobAllowed).to.be.equal(false);
+          await expect(tx_removeDelegate)
+          .to.emit(EPNSCoreV1Proxy, 'RemoveDelegate')
+          .withArgs(CHANNEL_CREATOR, BOB);
+      })
+
+
+   
     });
   });
 });


### PR DESCRIPTION
Removed the delegates mapping from inside the Channel Struct.

The previous delegates mapping has been replaced by the following mapping:
`    mapping(address => mapping (address => bool)) public delegated_NotificationSenders;
`
Following this approach will not just eliminate the need for an extra getter function but also be Upgrade Safe as upgrading a Struct might be troublesome. 

The test cases for the same has also been added in the test directory.
